### PR TITLE
fix attendance and smarter years

### DIFF
--- a/pmg/templates/attendance_overview.html
+++ b/pmg/templates/attendance_overview.html
@@ -5,7 +5,7 @@
 {% block page %}
 <section class="committee-attendance-overview">
   <h1><i class="fa fa-fw fa-table" aria-hidden="true"></i> Committee meeting attendance trends for {{ year }}</h1>
-  <p>This page shows the attendance rates of the committees in the <a href="#national-assembly">National Assembly</a> and the <a href="#ncop">National Council of Provinces</a> in 2017 as well as the change in attendance since 2016. The attendance rate is automatically updated as committees meet and attendance is recorded.</p>
+  <p>This page shows the attendance rates of the committees in the <a href="#national-assembly">National Assembly</a> and the <a href="#ncop">National Council of Provinces</a> in {{ year }} as well as the change in attendance since {{ year - 1 }}. The attendance rate is automatically updated as committees meet and attendance is recorded. In the first few weeks of a new year, when no committees have met yet, this page will show data of the previous year.</p>
   <p>You can click on a committee name to get more information; historical attendance rates as well as membership details can be found in the right sidebar of every committee page. It's also possible to download the raw data to do your own calculations and analysis.</p>
   <p>For MP and Minister attendance rates we'd like to refer you to <a href="https://www.pa.org.za/mp-attendance/">People's Assembly</a>.</p>
   <a class="btn btn-sm btn-success" href="https://api.pmg.org.za/committee-meeting-attendance/data.xlsx">Download data</a>
@@ -17,7 +17,7 @@
       <th class="th-cte-name">Committee</th>
       <th class="th-number-meetings hidden-xs" data-firstsort="desc">Meetings</th>
       <th class="th-attendance" data-defaultsort="desc">Attendance</th>
-      <th class="th-attendance-change">Since 2016</th>
+      <th class="th-attendance-change">Since {{ year - 1}}</th>
     </thead>
     {% for item in attendance_na %}
     <tr id="{{ item.committee_id }}">
@@ -53,8 +53,8 @@
       </td>
     </tr>
     {% endfor %}
-  </table> 
-  
+  </table>
+
   <h2 id="ncop">National Council of Provinces</h2>
   <table class="table table-hover sortable">
     <thead>
@@ -62,7 +62,7 @@
       <th class="th-cte-name">Committee</th>
       <th class="th-number-meetings hidden-xs">Meetings</th>
       <th class="th-attendance" data-defaultsort="desc">Attendance</th>
-      <th class="th-attendance-change">Since 2016</th>
+      <th class="th-attendance-change">Since {{ year - 1 }}</th>
     </thead>
     {% for item in attendance_ncop %}
     <tr id="{{ item.committee_id }}">

--- a/pmg/views.py
+++ b/pmg/views.py
@@ -334,7 +334,9 @@ def attendance_overview():
     """
     Display overview of attendance for meetings.
     """
-    this_year = datetime.today().year
+    # this_year = datetime.today().year
+    this_year = 2017
+    # Temporary fix for early in the year when there are no meetings yet, replace with line above after enough meetings
     last_year = this_year - 1
     attendance = CommitteeMeetingAttendance.annual_attendance_trends(last_year, this_year)
     # index by year and cte id

--- a/pmg/views.py
+++ b/pmg/views.py
@@ -334,9 +334,11 @@ def attendance_overview():
     """
     Display overview of attendance for meetings.
     """
-    # this_year = datetime.today().year
-    this_year = 2017
-    # Temporary fix for early in the year when there are no meetings yet, replace with line above after enough meetings
+    month = datetime.today().month
+    this_year = datetime.today().year
+    # in jan and feb only, show previous year's attendance data. months are 1-12
+    if month < 3:
+        this_year = this_year - 1
     last_year = this_year - 1
     attendance = CommitteeMeetingAttendance.annual_attendance_trends(last_year, this_year)
     # index by year and cte id


### PR DESCRIPTION
- Temporary fix for attendance when there are no meetings yet
- Text on attendance page doesn't need to be updated by year anymore, an update on `views.py` will update that too