### PR TITLE
2018 attendance in overview

### DIFF
--- a/pmg/templates/attendance_overview.html
+++ b/pmg/templates/attendance_overview.html
@@ -69,7 +69,7 @@
       <td class="rank">#{{ loop.index }}</td>
       <td class="cte-name"><a href="{{ url_for('committee_detail', committee_id=item.committee_id) }}">{{ item.committee }}</a></td>
       <td class="number-meetings hidden-xs">{{ item.n_meetings }}</td>
-      <td class="attendance">
+      <td class="attendance" data-value="{{ item.avg_attendance }}">
         <div class="progress">
           <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="{{ item.avg_attendance }}" aria-valuemin="0" aria-valuemax="100" style="width: {{ item.avg_attendance }}%;">
             {{ item.avg_attendance|round|int }}%

--- a/pmg/templates/attendance_overview.html
+++ b/pmg/templates/attendance_overview.html
@@ -24,7 +24,7 @@
       <td class="rank">#{{ loop.index }}</td>
       <td class="cte-name"><a href="{{ url_for('committee_detail', committee_id=item.committee_id) }}">{{ item.committee }}</a></td>
       <td class="number-meetings hidden-xs">{{ item.n_meetings }}</td>
-      <td class="attendance">
+      <td class="attendance" data-value="{{ item.avg_attendance }}">
         <div class="progress">
           <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="{{ item.avg_attendance }}" aria-valuemin="0" aria-valuemax="100" style="width: {{ item.avg_attendance }}%;">
             {{ item.avg_attendance|round|int }}%

--- a/pmg/views.py
+++ b/pmg/views.py
@@ -336,9 +336,6 @@ def attendance_overview():
     """
     month = datetime.today().month
     this_year = datetime.today().year
-    # in jan and feb only, show previous year's attendance data. months are 1-12
-    if month < 3:
-        this_year = this_year - 1
     last_year = this_year - 1
     attendance = CommitteeMeetingAttendance.annual_attendance_trends(last_year, this_year)
     # index by year and cte id


### PR DESCRIPTION
I've removed the 3 month logic from the attendance overview as I couldn't see how we could include a form of logic while also showing 2018 already. Perhaps we can add the logic for 1 month after January? That way it will remain but we'll also prevent it breaking early next year.

Added a `data-value` for the attendance column. For some reason the sorting wasn't working properly.