### PR TITLE
Generate private member bill code with B prefix from 2018

### DIFF
--- a/pmg/models/resources.py
+++ b/pmg/models/resources.py
@@ -102,6 +102,9 @@ class BillType(db.Model):
     def private_member_bill(cls):
         return cls.query.filter(cls.name == "Private Member Bill").one()
 
+    def is_private_member_bill(self):
+        return self.name == "Private Member Bill"
+
     def __unicode__(self):
         return unicode(self.description)
 
@@ -146,7 +149,10 @@ class Bill(ApiResource, db.Model):
 
     @property
     def code(self):
-        out = self.type.prefix if self.type else "X"
+        if self.type.is_private_member_bill() and self.year >= 2018:
+            out = 'B'
+        else:
+            out = self.type.prefix if self.type else "X"
         out += str(self.number) if self.number else ""
         out += "-" + str(self.year)
         return unicode(out)


### PR DESCRIPTION
Add BillType.is_private_member_bill() so that we don't hit the DB for
each item in a list of bills when getting the code.

This isn't perfect. BillType doesn't have a notion of date but private member bills' code needs that.

Another way of implementing this would be to have an additional flag on the bill to indicate it's a PMB or add a date notion to the BillType. I think this is simplest.

```
(jdb)-(11:20 AM Mon Apr 23)-(~/proj/code4sa/pmg/cms/pmg-cms-2):
 (private-member-bill-code-2018) $ grep -r \\.prefix pmg
pmg/models/resources.py:            out = self.type.prefix if self.type else "X"
```