### PR TITLE
Add caching to the v1 generic resource list/show API

### DIFF
--- a/pmg/__init__.py
+++ b/pmg/__init__.py
@@ -5,6 +5,7 @@ import os
 from flask import Flask
 from flask.ext.sqlalchemy import SQLAlchemy
 from flask.ext.migrate import Migrate
+from flask_caching import Cache
 from flask_wtf.csrf import CsrfProtect
 from flask_mail import Mail
 from flask_marshmallow import Marshmallow
@@ -20,6 +21,22 @@ app.config.from_pyfile('../config/config.py')
 with open('config/logging-%s.yaml' % env) as f:
     import yaml
     logging.config.dictConfig(yaml.load(f))
+
+
+# Setup Caching
+
+cache = Cache(app, config={
+    'CACHE_TYPE': 'filesystem',
+    'CACHE_DIR': '/tmp/pmg-cache',
+    'CACHE_DEFAULT_TIMEOUT': 60*60,
+})
+
+
+def no_cache(request):
+    if 'authentication-token' in request.headers:
+        return True
+    else:
+        return False
 
 
 db = SQLAlchemy(app, session_options={"autoflush": False})

--- a/pmg/__init__.py
+++ b/pmg/__init__.py
@@ -25,14 +25,19 @@ with open('config/logging-%s.yaml' % env) as f:
 
 # Setup Caching
 
+if app.config['DEBUG']:
+    cache_type = 'null'
+else:
+    cache_type = 'filesystem'
+
 cache = Cache(app, config={
-    'CACHE_TYPE': 'filesystem',
+    'CACHE_TYPE': cache_type,
     'CACHE_DIR': '/tmp/pmg-cache',
     'CACHE_DEFAULT_TIMEOUT': 60*60,
 })
 
 
-def no_cache(request):
+def should_skip_cache(request):
     if 'authentication-token' in request.headers:
         return True
     else:

--- a/pmg/api/v1.py
+++ b/pmg/api/v1.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import lazyload, joinedload
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql.expression import literal_column
 
-from pmg import db, app, cache, no_cache
+from pmg import db, app, cache, should_skip_cache
 from pmg.search import Search
 from pmg.models import *  # noqa
 from pmg.models.base import resource_slugs
@@ -315,7 +315,7 @@ def committee_list():
 @api.route('/<string:resource>/', )
 @api.route('/<string:resource>/<int:resource_id>/', )
 @load_user()
-@cache.memoize(unless=lambda: no_cache(request))
+@cache.memoize(unless=lambda: should_skip_cache(request))
 def resource_list(resource, resource_id=None):
     """
     Generic resource endpoints.

--- a/pmg/api/v1.py
+++ b/pmg/api/v1.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import lazyload, joinedload
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql.expression import literal_column
 
-from pmg import db, app
+from pmg import db, app, cache, no_cache
 from pmg.search import Search
 from pmg.models import *  # noqa
 from pmg.models.base import resource_slugs
@@ -315,6 +315,7 @@ def committee_list():
 @api.route('/<string:resource>/', )
 @api.route('/<string:resource>/<int:resource_id>/', )
 @load_user()
+@cache.memoize(unless=lambda: no_cache(request))
 def resource_list(resource, resource_id=None):
     """
     Generic resource endpoints.

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ fixture==1.5.9
 Flask==0.10.1
 Flask-Admin==1.4.2
 Flask-Assets==0.10
+Flask-Caching==1.4.0
 Flask-Login==0.2.11
 Flask-Mail==0.9.1
 flask-marshmallow==0.7.0


### PR DESCRIPTION
@cache.memoize caches a view function based on its arguments. It's important that it's around the thing that retuns the view result. If it's above @api.route it will cache its result instead of the view result which is not what we want.

pmg.no_cache is named after nginx's proxy_no_cache config item. In this case we don't serve from the cache if an authentication header is provided.

We can add similar annotations to other view functions.