### PR TITLE
Use date_of_introduction as primary search key for bills

### DIFF
--- a/pmg/views.py
+++ b/pmg/views.py
@@ -324,10 +324,10 @@ def committee_detail(committee_id):
 
     bills = load_from_api(
         'v2/committees/%s/bills' % committee_id,
-        fields=['id', 'title', 'status', 'date_of_introduction', 'code', 'number'],
+        fields=['id', 'title', 'status', 'date_of_introduction', 'code'],
     )['results']
 
-    bills.sort(key=lambda b: [b['date_of_introduction'], b.get('number', 0)], reverse=True)
+    bills.sort(key=lambda b: b['date_of_introduction'], reverse=True)
 
     return render_template('committee_detail.html',
                            current_year=now.year,

--- a/pmg/views.py
+++ b/pmg/views.py
@@ -208,14 +208,9 @@ def bills(bill_type, year=None):
     api_url = 'bill' if bill_type == 'all' else 'bill/%s' % bill_type
     bills = load_from_api(api_url, return_everything=True, params=params)['results']
 
-    # Sort bills by date_of_introduction, then other attributes.
-    # date_of_introduction == None defaults to the latest
-    bills.sort(key=lambda b: [-b['year'], b['type']['prefix'], b.get('number', 0), b['title']])
-    bills.sort(
-        key=lambda b: [
-            datetime.strptime(b['date_of_introduction'], '%Y-%m-%d').date()
-            if b['date_of_introduction'] else date.max],
-        reverse=True)
+    # Sort bills by number, date_of_introduction, and then other attributes.
+    bills.sort(key=lambda b: [-b['year'], b['type']['prefix'], b['title']])
+    bills.sort(key=lambda b: [b.get('number', 0), b['date_of_introduction']], reverse=True)
 
     status_dict = {
         "na": ("in progress", "label-primary"),

--- a/pmg/views.py
+++ b/pmg/views.py
@@ -326,10 +326,10 @@ def committee_detail(committee_id):
 
     bills = load_from_api(
         'v2/committees/%s/bills' % committee_id,
-        fields=['id', 'title', 'status', 'date_of_introduction', 'code'],
+        fields=['id', 'title', 'status', 'date_of_introduction', 'code', 'number'],
     )['results']
 
-    bills.sort(key=lambda b: b['date_of_introduction'], reverse=True)
+    bills.sort(key=lambda b: [b['date_of_introduction'], b.get('number', 0)], reverse=True)
 
     return render_template('committee_detail.html',
                            current_year=now.year,

--- a/pmg/views.py
+++ b/pmg/views.py
@@ -207,10 +207,8 @@ def bills(bill_type, year=None):
 
     api_url = 'bill' if bill_type == 'all' else 'bill/%s' % bill_type
     bills = load_from_api(api_url, return_everything=True, params=params)['results']
-
-    # Sort bills by number, date_of_introduction, and then other attributes.
-    bills.sort(key=lambda b: [-b['year'], b['type']['prefix'], b['title']])
-    bills.sort(key=lambda b: [b.get('number', 0), b['date_of_introduction']], reverse=True)
+ 
+    bills.sort(key=lambda b: [-b['year'], b['code'][0],  b.get('number', 0), b['title']])
 
     status_dict = {
         "na": ("in progress", "label-primary"),

--- a/pmg/views.py
+++ b/pmg/views.py
@@ -208,7 +208,14 @@ def bills(bill_type, year=None):
     api_url = 'bill' if bill_type == 'all' else 'bill/%s' % bill_type
     bills = load_from_api(api_url, return_everything=True, params=params)['results']
 
+    # Sort bills by date_of_introduction, then other attributes.
+    # date_of_introduction == None defaults to the latest
     bills.sort(key=lambda b: [-b['year'], b['type']['prefix'], b.get('number', 0), b['title']])
+    bills.sort(
+        key=lambda b: [
+            datetime.strptime(b['date_of_introduction'], '%Y-%m-%d').date()
+            if b['date_of_introduction'] else date.max],
+        reverse=True)
 
     status_dict = {
         "na": ("in progress", "label-primary"),


### PR DESCRIPTION
The list is sorted twice to sort by number and introduction dates in reverse order, and and then on other keys.

Sort by the secondary keys, then the primary key. See https://docs.python.org/2/howto/sorting.html#sort-stability-and-complex-sorts