### PR TITLE
Make context processors work outside of request context

### DIFF
--- a/pmg/helpers.py
+++ b/pmg/helpers.py
@@ -124,7 +124,11 @@ def get_ga_events_helper():
 
 @app.context_processor
 def feedback_form():
-    return {'correct_this_page_form': CorrectThisPageForm()}
+    if request:
+        form = CorrectThisPageForm()
+    else:
+        form = None
+    return {'correct_this_page_form': form}
 
 
 @app.context_processor

--- a/pmg/user_management.py
+++ b/pmg/user_management.py
@@ -167,7 +167,7 @@ def get_megamenu():
     recent_meetings = None
     user_follows_committees = False
 
-    if current_user.is_authenticated():
+    if current_user and current_user.is_authenticated():
         user_following = sorted(current_user.following, key=lambda cte: cte.name)[:20]
         if user_following:
             user_follows_committees = True
@@ -191,14 +191,13 @@ def get_megamenu():
 
 def follow_committee(committee_id):
     committee = Committee.query.get(committee_id)
-    
+
     if committee not in current_user.following:
         current_user.follow_committee(committee)
 
     if committee not in current_user.committee_alerts:
         current_user.committee_alerts.append(committee)
-    
+
     db.session.commit()
 
     ga_event('user', 'follow-committee', 'cte-follow-committee')
-

--- a/pmg/views.py
+++ b/pmg/views.py
@@ -150,7 +150,7 @@ def get_featured_content():
 def inject_via():
     # inject the 'via' query param into the page (easier than parsing the querystring in JS)
     # so that we can track it with GA
-    if request.args.get('via'):
+    if request and request.args.get('via'):
         return {'via_tag': request.args.get('via').strip()}
     return {'via_tag': None}
 


### PR DESCRIPTION
Make context processors check for the existence of request
or current user before trying to use them.

This is needed because they're always invoked when rendering
but we need to render without a request context for periodic mails