### PR TITLE
Fix discrepancy between models and prod schema - user timestamps with/without timezone

### DIFF
--- a/pmg/models/users.py
+++ b/pmg/models/users.py
@@ -89,9 +89,9 @@ class User(db.Model, UserMixin):
     name = db.Column(db.String(255), nullable=True)
     password = db.Column(db.String(255), default='', server_default='', nullable=False)
     active = db.Column(db.Boolean(), default=True, server_default=sql.expression.true())
-    confirmed_at = db.Column(db.DateTime(timezone=True))
-    last_login_at = db.Column(db.DateTime(timezone=True))
-    current_login_at = db.Column(db.DateTime(timezone=True))
+    confirmed_at = db.Column(db.DateTime(timezone=False))
+    last_login_at = db.Column(db.DateTime(timezone=False))
+    current_login_at = db.Column(db.DateTime(timezone=False))
     last_login_ip = db.Column(db.String(100))
     current_login_ip = db.Column(db.String(100))
     login_count = db.Column(db.Integer)
@@ -125,7 +125,7 @@ class User(db.Model, UserMixin):
 
     def update_current_login(self):
         now = datetime.datetime.utcnow()
-        if self.current_login_at.replace(tzinfo=None) + datetime.timedelta(hours=1) < now:
+        if self.current_login_at + datetime.timedelta(hours=1) < now:
             self.current_login_at = now
             db.session.commit()
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -89,6 +89,12 @@ class PMGLiveServerTestCase(LiveServerTestCase):
         self.assertEqual(200, response.code)
         self.html = response.read()
 
+    def make_request(self, url, **args):
+        with self.app.test_client() as client:
+            response = client.open(url, **args)
+            self.html = response.data
+            return response
+
     def request_as_user(self, user, url, **args):
         with self.app.test_client() as client:
             with client.session_transaction() as session:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -24,6 +24,7 @@ class PMGTestCase(TestCase):
 
 
 class PMGLiveServerTestCase(LiveServerTestCase):
+
     def __call__(self, result=None):
         """
         Does the required setup, doing it here means you don't have to
@@ -33,6 +34,7 @@ class PMGLiveServerTestCase(LiveServerTestCase):
         # Get the app
         self.app = self.create_app()
         self.port = self.app.config.get("LIVESERVER_PORT", 5000)
+        self.base_url = "http://pmg.test:5000/"
 
         # We need to create a context in order for extensions to catch up
         self._ctx = self.app.test_request_context()
@@ -84,17 +86,12 @@ class PMGLiveServerTestCase(LiveServerTestCase):
         db.session.remove()
         db.drop_all()
 
-    def get_page_contents(self, url):
-        response = urllib2.urlopen(url)
-        self.assertEqual(200, response.code)
-        self.html = response.read()
-
-    def make_request(self, url, user=None, **args):
+    def make_request(self, path, user=None, **args):
         """
         Make a request to the test app (optionally with a user session).
 
         Args:
-            url: Endpoint to make the request to.
+            path: Endpoint to make the request to.
             user: User to make the request as.
         
         Keyword arguments are passed on to the test client 
@@ -105,7 +102,7 @@ class PMGLiveServerTestCase(LiveServerTestCase):
                 session['user_id'] = user.id if user else None
                 session['fresh'] = True
 
-            response = client.open(url, **args)
+            response = client.open(path, base_url=self.base_url, **args)
             self.html = response.data
             return response
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -89,16 +89,20 @@ class PMGLiveServerTestCase(LiveServerTestCase):
         self.assertEqual(200, response.code)
         self.html = response.read()
 
-    def make_request(self, url, **args):
-        with self.app.test_client() as client:
-            response = client.open(url, **args)
-            self.html = response.data
-            return response
+    def make_request(self, url, user=None, **args):
+        """
+        Make a request to the test app (optionally with a user session).
 
-    def request_as_user(self, user, url, **args):
+        Args:
+            url: Endpoint to make the request to.
+            user: User to make the request as.
+        
+        Keyword arguments are passed on to the test client 
+        (https://werkzeug.palletsprojects.com/en/0.15.x/test/#testing-api).
+        """
         with self.app.test_client() as client:
             with client.session_transaction() as session:
-                session['user_id'] = user.id
+                session['user_id'] = user.id if user else None
                 session['fresh'] = True
 
             response = client.open(url, **args)

--- a/tests/views/test_admin_alerts_page.py
+++ b/tests/views/test_admin_alerts_page.py
@@ -33,10 +33,10 @@ class TestAdminAlertsPage(PMGLiveServerTestCase):
 
     def test_admin_alerts_page(self):
         """
-        Test admin alerts page (http://pmg.test:5000/admin/alerts)
+        Test admin alerts page (/admin/alerts)
         """
-        self.request_as_user(
-            self.user, "http://pmg.test:5000/admin/alerts", follow_redirects=True)
+        self.make_request(
+            "/admin/alerts", self.user, follow_redirects=True)
         self.assertIn('Send an email alert', self.html)
         self.assertIn('What template would you like to use?', self.html)
         self.assertIn('If none of these are suitable, <a href="/admin/email-templates/new/">create a new template', self.html)
@@ -44,12 +44,12 @@ class TestAdminAlertsPage(PMGLiveServerTestCase):
 
     def test_admin_alerts_new_page(self):
         """
-        Test admin new alerts page (http://pmg.test:5000/admin/alerts/new)
+        Test admin new alerts page (/admin/alerts/new)
         """
-        self.request_as_user(
-            self.user, 
-            "http://pmg.test:5000/admin/alerts/new?template_id=%d" % \
+        self.make_request(
+            "/admin/alerts/new?template_id=%d" % \
             self.fx.EmailTemplateData.template_one.id, 
+            self.user, 
             follow_redirects=True)
         self.assertIn('Send an email alert: %s' % \
             self.fx.EmailTemplateData.template_one.name, self.html)
@@ -63,11 +63,11 @@ class TestAdminAlertsPage(PMGLiveServerTestCase):
 
     def test_post_admin_alerts_new_page_preview(self):
         """
-        Test admin new alerts page preview (http://pmg.test:5000/admin/alerts/preview)
+        Test admin new alerts page preview (/admin/alerts/preview)
         """
-        response = self.request_as_user(
+        response = self.make_request(
+            "/admin/alerts/preview", 
             self.user, 
-            "http://pmg.test:5000/admin/alerts/preview", 
             data=self.create_alert_data, method="POST", follow_redirects=True)
         self.assertEqual(200, response.status_code)
         self.assertIn('Subject', self.html)
@@ -76,11 +76,11 @@ class TestAdminAlertsPage(PMGLiveServerTestCase):
     @patch('pmg.admin.email_alerts.send_sendgrid_email', return_value=True)
     def test_post_admin_alerts_new_page(self, mock):
         """
-        Test submit admin new alerts page (http://pmg.test:5000/admin/alerts/new)
+        Test submit admin new alerts page (/admin/alerts/new)
         """
-        response = self.request_as_user(
+        response = self.make_request(
+            "/admin/alerts/new", 
             self.user, 
-            "http://pmg.test:5000/admin/alerts/new", 
             data=self.create_alert_data, method="POST", follow_redirects=True)
         self.assertEqual(200, response.status_code)
         self.assertIn(

--- a/tests/views/test_admin_bill_page.py
+++ b/tests/views/test_admin_bill_page.py
@@ -83,27 +83,28 @@ class TestAdminBillPage(PMGLiveServerTestCase):
     def test_admin_delete_bill(self):
         """
         Delete a bill on the admin interface 
-        (http://pmg.test:5000/admin/bill/delete/)
+        (/admin/bill/delete/)
         """
         before_count = len(Bill.query.all())
-        url = "http://pmg.test:5000/admin/bill/delete/"
+        url = "/admin/bill/delete/"
         data = {
             'url': '/admin/bill/',
             'id' : str(self.fx.BillData.food.id),
             
         }
-        response = self.request_as_user(self.user, url, data=data, method="POST")
+        response = self.make_request(
+            url, self.user, follow_redirects=True, data=data, method="POST")
         after_count = len(Bill.query.all())
-        self.assertEqual(302, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertGreater(before_count, after_count)
 
     def test_admin_edit_bill(self):
         """
-        Edit a bill with the admin interface (http://pmg.test:5000/admin/bill/edit/)
+        Edit a bill with the admin interface (/admin/bill/edit/)
         """
         bill = db.session.query(Bill).first()
         new_title = 'Cool Bill'
-        url = "http://pmg.test:5000/admin/bill/edit/?id=%d" % bill.id
+        url = "/admin/bill/edit/?id=%d" % bill.id
         data = {
             'year': '2020',
             'title': new_title,
@@ -115,8 +116,8 @@ class TestAdminBillPage(PMGLiveServerTestCase):
             'effective_date': '2019-07-03',
             'act_name': 'Fundamental',
         }
-        response = self.request_as_user(self.user, url, data=data, 
-            method="POST", follow_redirects=True)
+        response = self.make_request(
+            url, self.user, follow_redirects=True, data=data, method="POST")
         self.assertEqual(200, response.status_code)
 
         db.session.refresh(bill)

--- a/tests/views/test_admin_bill_page.py
+++ b/tests/views/test_admin_bill_page.py
@@ -25,8 +25,8 @@ class TestAdminBillPage(PMGLiveServerTestCase):
         """
         Test admin bill page (http://pmg.test:5000/admin/bill)
         """
-        self.request_as_user(
-            self.user, "http://pmg.test:5000/admin/bill", follow_redirects=True)
+        self.make_request(
+            "http://pmg.test:5000/admin/bill", self.user, follow_redirects=True)
         self.assertIn('Bills', self.html)
         self.containsBill(self.fx.BillData.farm)
         self.containsBill(self.fx.BillData.food)
@@ -53,7 +53,7 @@ class TestAdminBillPage(PMGLiveServerTestCase):
             'effective_date': '2019-07-03',
             'act_name': 'Fundamental',
         }
-        response = self.request_as_user(self.user, url, data=data, method="POST")
+        response = self.make_request(url, self.user, data=data, method="POST")
         after_count = len(Bill.query.all())
         self.assertEqual(302, response.status_code)
         self.assertLess(before_count, after_count)
@@ -76,7 +76,7 @@ class TestAdminBillPage(PMGLiveServerTestCase):
                 str(self.fx.BillData.food.id),
             ]
         }
-        response = self.request_as_user(self.user, url, data=data, method="POST")
+        response = self.make_request(url, self.user, data=data, method="POST")
         after_count = len(Bill.query.all())
         self.assertEqual(302, response.status_code)
         self.assertGreater(before_count, after_count)

--- a/tests/views/test_admin_bill_page.py
+++ b/tests/views/test_admin_bill_page.py
@@ -23,10 +23,10 @@ class TestAdminBillPage(PMGLiveServerTestCase):
 
     def test_admin_bill_page(self):
         """
-        Test admin bill page (http://pmg.test:5000/admin/bill)
+        Test admin bill page (/admin/bill)
         """
         self.make_request(
-            "http://pmg.test:5000/admin/bill", self.user, follow_redirects=True)
+            "/admin/bill", self.user, follow_redirects=True)
         self.assertIn('Bills', self.html)
         self.containsBill(self.fx.BillData.farm)
         self.containsBill(self.fx.BillData.food)
@@ -38,10 +38,10 @@ class TestAdminBillPage(PMGLiveServerTestCase):
 
     def test_admin_create_bill(self):
         """
-        Create a bill with the admin interface (http://pmg.test:5000/admin/bill/new/)
+        Create a bill with the admin interface (/admin/bill/new/)
         """
         before_count = len(Bill.query.all())
-        url = "http://pmg.test:5000/admin/bill/new/?url=%2Fadmin%2Fbill%2F"
+        url = "/admin/bill/new/?url=%2Fadmin%2Fbill%2F"
         data = {
             'year': '2020',
             'title': 'Cool Bill',
@@ -64,11 +64,10 @@ class TestAdminBillPage(PMGLiveServerTestCase):
 
     def test_admin_action_bill(self):
         """
-        Delete a bill with the action url on the admin interface 
-        (http://pmg.test:5000/admin/bill/action/)
+        Delete a bill with the admin interface (/admin/bill/action/)
         """
         before_count = len(Bill.query.all())
-        url = "http://pmg.test:5000/admin/bill/action/"
+        url = "/admin/bill/action/"
         data = {
             'url': '/admin/bill/',
             'action': 'delete',

--- a/tests/views/test_admin_bill_page.py
+++ b/tests/views/test_admin_bill_page.py
@@ -68,8 +68,8 @@ class TestAdminBillPage(PMGLiveServerTestCase):
         The admin bill create page should show help text for
         which bill event title are allowed when the bill type is "bill-passed".
         """
-        url = "http://pmg.test:5000/admin/bill/new"
-        response = self.request_as_user(self.user, url, follow_redirects=True)
+        url = "/admin/bill/new"
+        response = self.make_request(url, self.user, follow_redirects=True)
 
         self.assertIn(escape('Help?'), self.html)
         self.assertIn(

--- a/tests/views/test_admin_committee_page.py
+++ b/tests/views/test_admin_committee_page.py
@@ -22,10 +22,10 @@ class TestAdminCommitteePage(PMGLiveServerTestCase):
 
     def test_view_admin_committee_page(self):
         """
-        Test view admin committee page (http://pmg.test:5000/admin/committee)
+        Test view admin committee page (/admin/committee)
         """
         self.make_request(
-            "http://pmg.test:5000/admin/committee", self.user, follow_redirects=True)
+            "/admin/committee", self.user, follow_redirects=True)
         self.assertIn('Committees', self.html)
         self.containsCommittee(self.fx.CommitteeData.communications)
         self.containsCommittee(self.fx.CommitteeData.arts)
@@ -38,10 +38,10 @@ class TestAdminCommitteePage(PMGLiveServerTestCase):
 
     def test_admin_create_committee(self):
         """
-        Create a committee with the admin interface (http://pmg.test:5000/admin/committee/new/)
+        Create a committee with the admin interface (/admin/committee/new/)
         """
         before_count = len(Committee.query.all())
-        url = "http://pmg.test:5000/admin/committee/new/?url=%2Fadmin%2Fcommittee%2F"
+        url = "/admin/committee/new/?url=%2Fadmin%2Fcommittee%2F"
         data = {
             'name': 'New committee',
             'active': 'y',
@@ -62,10 +62,10 @@ class TestAdminCommitteePage(PMGLiveServerTestCase):
 
     def test_admin_delete_committee(self):
         """
-        Delete a committee with the admin interface (http://pmg.test:5000/admin/committee/action/)
+        Delete a committee with the admin interface (/admin/committee/action/)
         """
         before_count = len(Committee.query.all())
-        url = "http://pmg.test:5000/admin/committee/action/"
+        url = "/admin/committee/action/"
         data = {
             'url': '/admin/committee/',
             'action': 'delete',

--- a/tests/views/test_admin_committee_page.py
+++ b/tests/views/test_admin_committee_page.py
@@ -24,8 +24,8 @@ class TestAdminCommitteePage(PMGLiveServerTestCase):
         """
         Test view admin committee page (http://pmg.test:5000/admin/committee)
         """
-        self.request_as_user(
-            self.user, "http://pmg.test:5000/admin/committee", follow_redirects=True)
+        self.make_request(
+            "http://pmg.test:5000/admin/committee", self.user, follow_redirects=True)
         self.assertIn('Committees', self.html)
         self.containsCommittee(self.fx.CommitteeData.communications)
         self.containsCommittee(self.fx.CommitteeData.arts)
@@ -51,7 +51,7 @@ class TestAdminCommitteePage(PMGLiveServerTestCase):
             'about': '',
             'contact_details': '',
         }
-        response = self.request_as_user(self.user, url, data=data, method="POST")
+        response = self.make_request(url, self.user, data=data, method="POST")
         after_count = len(Committee.query.all())
         self.assertEqual(302, response.status_code)
         self.assertLess(before_count, after_count)
@@ -73,7 +73,7 @@ class TestAdminCommitteePage(PMGLiveServerTestCase):
                 str(self.fx.CommitteeData.communications.id),
             ]
         }
-        response = self.request_as_user(self.user, url, data=data, method="POST")
+        response = self.make_request(url, self.user, data=data, method="POST")
         after_count = len(Committee.query.all())
         self.assertEqual(302, response.status_code)
         self.assertGreater(before_count, after_count)

--- a/tests/views/test_admin_member_page.py
+++ b/tests/views/test_admin_member_page.py
@@ -24,8 +24,8 @@ class TestAdminMemberPage(PMGLiveServerTestCase):
         """
         Test view admin member page (http://pmg.test:5000/admin/member)
         """
-        self.request_as_user(
-            self.user, "http://pmg.test:5000/admin/member", follow_redirects=True)
+        self.make_request(
+            "http://pmg.test:5000/admin/member", self.user, follow_redirects=True)
         self.assertIn('Members', self.html)
         self.containsMember(self.fx.MemberData.veronica)
         self.containsMember(self.fx.MemberData.laetitia)
@@ -60,8 +60,8 @@ class TestAdminMemberPage(PMGLiveServerTestCase):
             'bio': '',
             'pa_link': '',
         }
-        response = self.request_as_user(
-            self.user, url, data=data, method="POST")
+        response = self.make_request(
+            url, self.user, data=data, method="POST")
         after_count = len(Member.query.all())
         self.assertEqual(302, response.status_code)
         self.assertLess(before_count, after_count)
@@ -84,7 +84,7 @@ class TestAdminMemberPage(PMGLiveServerTestCase):
                 str(self.fx.MemberData.veronica.id),
             ]
         }
-        response = self.request_as_user(self.user, url, data=data, method="POST")
+        response = self.make_request(url, self.user, data=data, method="POST")
         after_count = len(Member.query.all())
         self.assertEqual(302, response.status_code)
         self.assertGreater(before_count, after_count)

--- a/tests/views/test_admin_member_page.py
+++ b/tests/views/test_admin_member_page.py
@@ -22,10 +22,10 @@ class TestAdminMemberPage(PMGLiveServerTestCase):
 
     def test_view_admin_member_page(self):
         """
-        Test view admin member page (http://pmg.test:5000/admin/member)
+        Test view admin member page (/admin/member)
         """
         self.make_request(
-            "http://pmg.test:5000/admin/member", self.user, follow_redirects=True)
+            "/admin/member", self.user, follow_redirects=True)
         self.assertIn('Members', self.html)
         self.containsMember(self.fx.MemberData.veronica)
         self.containsMember(self.fx.MemberData.laetitia)
@@ -46,10 +46,10 @@ class TestAdminMemberPage(PMGLiveServerTestCase):
 
     def test_admin_create_member(self):
         """
-        Create a member with the admin interface (http://pmg.test:5000/admin/member/new/)
+        Create a member with the admin interface (/admin/member/new/)
         """
         before_count = len(Member.query.all())
-        url = "http://pmg.test:5000/admin/member/new/?url=%2Fadmin%2Fmember%2F"
+        url = "/admin/member/new/?url=%2Fadmin%2Fmember%2F"
         data = {
             'name': 'New member',
             'current': 'y',
@@ -73,10 +73,10 @@ class TestAdminMemberPage(PMGLiveServerTestCase):
 
     def test_admin_delete_member(self):
         """
-        Delete a member with the admin interface (http://pmg.test:5000/admin/member/action/)
+        Delete a member with the admin interface (/admin/member/action/)
         """
         before_count = len(Member.query.all())
-        url = "http://pmg.test:5000/admin/member/action/"
+        url = "/admin/member/action/"
         data = {
             'url': '/admin/member/',
             'action': 'delete',

--- a/tests/views/test_admin_view.py
+++ b/tests/views/test_admin_view.py
@@ -20,16 +20,15 @@ class TestAdminView(PMGLiveServerTestCase):
 
     def test_admin_page_unauthorised(self):
         """
-        Test admin page (http://pmg.test:5000/admin) unauthorised
+        Test admin page (/admin) unauthorised
         """
-        self.get_page_contents("http://pmg.test:5000/admin")
+        self.make_request("/admin", follow_redirects=True)
         self.assertIn('Login now', self.html)
 
     def test_admin_page_authorised(self):
         """
-        Test admin page (http://pmg.test:5000/admin) authorised
+        Test admin page (/admin) authorised
         """
         user = self.fx.UserData.admin
-        self.make_request(
-            "http://pmg.test:5000/admin", user, follow_redirects=True)
+        self.make_request("/admin", user, follow_redirects=True)
         self.assertIn('Record counts', self.html)

--- a/tests/views/test_admin_view.py
+++ b/tests/views/test_admin_view.py
@@ -30,6 +30,6 @@ class TestAdminView(PMGLiveServerTestCase):
         Test admin page (http://pmg.test:5000/admin) authorised
         """
         user = self.fx.UserData.admin
-        self.request_as_user(
-            user, "http://pmg.test:5000/admin", follow_redirects=True)
+        self.make_request(
+            "http://pmg.test:5000/admin", user, follow_redirects=True)
         self.assertIn('Record counts', self.html)

--- a/tests/views/test_attendance_overview.py
+++ b/tests/views/test_attendance_overview.py
@@ -96,7 +96,7 @@ class TestAttendanceOverview(PMGLiveServerTestCase):
         db.session.commit()
 
     def test_attendance_overview(self):
-        self.get_page_contents("http://pmg.test:5000/attendance-overview")
+        self.make_request("/attendance-overview")
         self.assertIn("Committee meeting attendance trends for 2019", self.html)
         self.assertIn("Arts and Culture", self.html)
         self.assertIn("50%", self.html)

--- a/tests/views/test_bills_pages.py
+++ b/tests/views/test_bills_pages.py
@@ -30,9 +30,9 @@ class TestBillsPages(PMGLiveServerTestCase):
 
     def test_bills_page(self):
         """
-        Test bills page (http://pmg.test:5000/bills)
+        Test bills page (/bills)
         """
-        self.get_page_contents("http://pmg.test:5000/bills")
+        self.make_request("/bills", follow_redirects=True)
         headings = ['Current Bills', 'All Tabled Bills',
                     'Private Member &amp; Committee Bills',
                     'All Tabled &amp; Draft Bills',
@@ -42,9 +42,9 @@ class TestBillsPages(PMGLiveServerTestCase):
 
     def test_current_bills_page(self):
         """
-        Test current bills page (http://pmg.test:5000/bills/current)
+        Test current bills page (/bills/current)
         """
-        self.get_page_contents("http://pmg.test:5000/bills/current")
+        self.make_request("/bills/current", follow_redirects=True)
         self.assertIn('Current Bills', self.html)
         self.assertIn('Weekly update for all current bills', self.html)
         for bill_key in self.fx.BillData:
@@ -53,19 +53,6 @@ class TestBillsPages(PMGLiveServerTestCase):
                 self.contains_bill(bill)
             else:
                 self.doesnt_contain_bill(bill)
-
-    # def test_draft_bills_page(self):
-    #     """
-    #     Test draft bills page (http://pmg.test:5000/bills/draft/year/<year>)
-    #     """
-    #     self.get_page_contents("http://pmg.test:5000/bills/draft/year/2019")
-    #     self.assertIn('Draft Bills from 2019', self.html)
-    #     for bill_key in self.fx.BillData:
-    #         bill = getattr(self.fx.BillData, bill_key[0])
-    #         if bill.status and bill.status.name in self.current_statuses:
-    #             self.contains_bill(bill)
-    #         else:
-    #             self.doesnt_contain_bill(bill)
 
     def contains_bill(self, bill):
         self.assertIn(bill.title, self.html)

--- a/tests/views/test_blog_pages.py
+++ b/tests/views/test_blog_pages.py
@@ -18,19 +18,19 @@ class TestBlogPages(PMGLiveServerTestCase):
 
     def test_blog_post_page(self):
         """
-        Test blog post page (http://pmg.test:5000/blog/<slug>)
+        Test blog post page (/blog/<slug>)
         """
         post = self.fx.PostData.the_week_ahead
-        self.get_page_contents("http://pmg.test:5000/blog/%s/" % post.slug)
+        self.make_request("/blog/%s/" % post.slug)
         self.assertIn(post.title, self.html)
         self.assertIn(post.body[0:100], self.html)
         self.assertIn('That week in Parliament', self.html)
 
     def test_blog_listings_page(self):
         """
-        Test blog listings page (http://pmg.test:5000/blog)
+        Test blog listings page (/blog)
         """
-        self.get_page_contents("http://pmg.test:5000/blog")
+        self.make_request("/blog/")
         self.contains_template_text()
         self.contains_posts(Post.query.all())
         self.contains_archive()
@@ -38,12 +38,12 @@ class TestBlogPages(PMGLiveServerTestCase):
     def test_blog_listings_page_with_filter(self):
         """
         Test blog listings page with a filter 
-        (http://pmg.test:5000/blog?filter[month]=<month>&filter[year]=<year>).
+        (/blog?filter[month]=<month>&filter[year]=<year>).
         """
         month = 'February'
         year = 2019
-        self.get_page_contents(
-            "http://pmg.test:5000/blog?filter[month]=%s&filter[year]=%d" %
+        self.make_request(
+            "/blog/?filter[month]=%s&filter[year]=%d" %
             (month, year))
         self.contains_template_text()
         self.contains_posts([

--- a/tests/views/test_committee_meeting_page.py
+++ b/tests/views/test_committee_meeting_page.py
@@ -16,11 +16,11 @@ class TestCommitteeMeetingPage(PMGLiveServerTestCase):
 
     def test_premium_committee_meeting(self):
         """
-        Test premium committee meeting page (http://pmg.test:5000/committee-meeting/<id>/)
+        Test premium committee meeting page (/committee-meeting/<id>/)
         """
         meeting = self.fx.CommitteeMeetingData.premium_recent
-        self.get_page_contents(
-            "http://pmg.test:5000/committee-meeting/%s/"
+        self.make_request(
+            "/committee-meeting/%s/"
             % meeting.id
         )
         self.assertIn(meeting.title, self.html)

--- a/tests/views/test_committee_page.py
+++ b/tests/views/test_committee_page.py
@@ -39,12 +39,12 @@ class TestCommitteePage(PMGLiveServerTestCase):
     def test_committee_page_write_to_committee_facet(self):
         """
         Test the presence of the "Write to committee" facet on the 
-        committee page (http://pmg.test:5000/committee/<id>/)
+        committee page (/committee/<id>/)
         """
         for committee_tuple in self.fx.CommitteeData:
             committee = committee_tuple[1]
-            self.get_page_contents(
-                "http://pmg.test:5000/committee/%s/"
+            self.make_request(
+                "/committee/%s/"
                 % committee.id
             )
             if committee.active and committee.house.name_short == 'NA':

--- a/tests/views/test_committee_page.py
+++ b/tests/views/test_committee_page.py
@@ -22,12 +22,11 @@ class TestCommitteePage(PMGLiveServerTestCase):
 
     def test_committee_page(self):
         """
-        Test committee page (http://pmg.test:5000/committee/<id>/)
+        Test committee page (/committee/<id>/)
         """
         committee = self.fx.CommitteeData.arts
-        self.get_page_contents(
-            "http://pmg.test:5000/committee/%s/"
-            % committee.id
+        self.make_request(
+            "/committee/%s/" % committee.id
         )
         self.assertIn(committee.name, self.html)
         self.containsCommitteeMeetings()

--- a/tests/views/test_committees_page.py
+++ b/tests/views/test_committees_page.py
@@ -19,9 +19,9 @@ class TestCommitteesPage(PMGLiveServerTestCase):
 
     def test_committees_page(self):
         """
-        Test committees page (http://pmg.test:5000/committees)
+        Test committees page (/committees)
         """
-        self.get_page_contents("http://pmg.test:5000/committees")
+        self.make_request("/committees", follow_redirects=True)
         self.assertIn('Parliamentary Committees', self.html)
         self.assertIn(self.fx.CommitteeData.communications.name, self.html)
         self.assertIn(self.fx.CommitteeData.arts.name, self.html)

--- a/tests/views/test_home_page.py
+++ b/tests/views/test_home_page.py
@@ -36,11 +36,9 @@ class TestHomePage(PMGLiveServerTestCase):
 
     def test_members_page(self):
         """
-        Test home page (http://pmg.test:5000/home)
+        Test home page (/home)
         """
-        self.get_page_contents(
-            "http://pmg.test:5000"
-        )
+        self.make_request("/")
         for navigation in self.NAVIGATION:
             self.assertIn(navigation, self.html, 'Page should contain navigation heading "%s"' % navigation)
         

--- a/tests/views/test_login_page.py
+++ b/tests/views/test_login_page.py
@@ -20,9 +20,9 @@ class TestLoginPage(PMGLiveServerTestCase):
 
     def test_view_login(self):
         """
-        Test view login (http://pmg.test:5000/user/login).
+        Test view login (/user/login).
         """
-        response = self.make_request("http://pmg.test:5000/user/login/",
+        response = self.make_request("/user/login/",
                                      follow_redirects=True)
         self.assertEqual(200, response.status_code)
         self.assertIn('Login now to view premium content', self.html)
@@ -31,13 +31,13 @@ class TestLoginPage(PMGLiveServerTestCase):
 
     def test_submit_login(self):
         """
-        Test submit login (http://pmg.test:5000/user/login).
+        Test submit login (/user/login).
         """
         user = User.query.first()
         password = 'password'
         user.password = encrypt_password(password)
         data = {'email': user.email, 'password': password}
-        response = self.make_request("http://pmg.test:5000/user/login/",
+        response = self.make_request("/user/login/",
                                      follow_redirects=True,
                                      method="POST",
                                      data=data)

--- a/tests/views/test_login_page.py
+++ b/tests/views/test_login_page.py
@@ -1,0 +1,45 @@
+from tests import PMGLiveServerTestCase
+from pmg.models import db, User
+from tests.fixtures import (dbfixture, UserData, RoleData)
+from flask_security.utils import encrypt_password
+
+
+class TestLoginPage(PMGLiveServerTestCase):
+    def setUp(self):
+        super(TestLoginPage, self).setUp()
+
+        self.fx = dbfixture.data(
+            RoleData,
+            UserData,
+        )
+        self.fx.setup()
+
+    def tearDown(self):
+        self.fx.teardown()
+        super(TestLoginPage, self).tearDown()
+
+    def test_view_login(self):
+        """
+        Test view login (http://pmg.test:5000/user/login).
+        """
+        response = self.make_request("http://pmg.test:5000/user/login/",
+                                     follow_redirects=True)
+        self.assertEqual(200, response.status_code)
+        self.assertIn('Login now to view premium content', self.html)
+        self.assertIn('Email Address', self.html)
+        self.assertIn('Password', self.html)
+
+    def test_submit_login(self):
+        """
+        Test submit login (http://pmg.test:5000/user/login).
+        """
+        user = User.query.first()
+        password = 'password'
+        user.password = encrypt_password(password)
+        data = {'email': user.email, 'password': password}
+        response = self.make_request("http://pmg.test:5000/user/login/",
+                                     follow_redirects=True,
+                                     method="POST",
+                                     data=data)
+        self.assertEqual(200, response.status_code)
+        self.assertIn('Log Out', self.html)

--- a/tests/views/test_members_page.py
+++ b/tests/views/test_members_page.py
@@ -19,12 +19,10 @@ class TestMemberPage(PMGLiveServerTestCase):
 
     def test_members_page(self):
         """
-        Test members page (http://pmg.test:5000/members)
+        Test members page (/members)
         """
         committee = self.fx.MemberData.veronica
-        self.get_page_contents(
-            "http://pmg.test:5000/members/"
-        )
+        self.make_request("/members/")
         self.assertIn('Members of Parliament', self.html)
         self.assertIn('Search for members', self.html)
 


### PR DESCRIPTION
- Set the timezone to `False` in https://github.com/OpenUpSA/pmg-cms-2/pull/373/files#diff-399112fc9af69d65c21f8d23a11297a5 and remove changes made last time for the timezones.
- Added a test for the login page to ensure the timezone changes doesn't break it in https://github.com/OpenUpSA/pmg-cms-2/pull/373/files#diff-5b3759795284af4fd09d0419e21e1692
- Also refactored the tests a little bit to remove the need for each test to know the base url (e.g. http://pmg.test:5000/).