### PR TITLE
Fix CKEditor bugs

### DIFF
--- a/pmg/admin/__init__.py
+++ b/pmg/admin/__init__.py
@@ -445,10 +445,10 @@ class CommitteeView(MyModelView):
     )
     form_widget_args = {
         'about': {
-            'class': 'ckeditor'
+            'class': 'ckeditor_instance'
         },
         'contact_details': {
-            'class': 'ckeditor'
+            'class': 'ckeditor_instance'
         },
     }
     form_args = {
@@ -657,10 +657,10 @@ class CommitteeMeetingView(EventView):
     }
     form_widget_args = {
         'body': {
-            'class': 'ckeditor'
+            'class': 'ckeditor_instance'
         },
         'summary': {
-            'class': 'ckeditor'
+            'class': 'ckeditor_instance'
         }
     }
     form_ajax_refs = {'bills': {'fields': ('title', ), 'page_size': 50}}
@@ -711,7 +711,7 @@ class HansardView(EventView):
     }
     form_widget_args = {
         'body': {
-            'class': 'ckeditor'
+            'class': 'ckeditor_instance'
         },
     }
     form_ajax_refs = {'bills': {'fields': ('title', ), 'page_size': 50}}
@@ -731,7 +731,7 @@ class ProvincialLegislatureView(MyModelView):
     )
     form_widget_args = {
         'contact_details': {
-            'class': 'ckeditor'
+            'class': 'ckeditor_instance'
         },
         'name': {
             'readonly': True
@@ -780,10 +780,10 @@ class BriefingView(EventView):
     )
     form_widget_args = {
         'summary': {
-            'class': 'ckeditor'
+            'class': 'ckeditor_instance'
         },
         'body': {
-            'class': 'ckeditor'
+            'class': 'ckeditor_instance'
         },
     }
     inline_models = [InlineFile(EventFile)]
@@ -898,7 +898,7 @@ class CommitteeQuestionView(MyModelView):
     }
     form_widget_args = {
         'answer': {
-            'class': 'ckeditor'
+            'class': 'ckeditor_instance'
         },
     }
     form_ajax_refs = {
@@ -961,7 +961,7 @@ class QuestionReplyView(MyModelView):
     )
     form_widget_args = {
         'body': {
-            'class': 'ckeditor'
+            'class': 'ckeditor_instance'
         },
     }
     inline_models = [InlineFile(QuestionReplyFile)]
@@ -993,7 +993,7 @@ class CallForCommentView(MyModelView):
     )
     form_widget_args = {
         'body': {
-            'class': 'ckeditor'
+            'class': 'ckeditor_instance'
         },
     }
 
@@ -1015,7 +1015,7 @@ class DailyScheduleView(ViewWithFiles, MyModelView):
     )
     form_widget_args = {
         'body': {
-            'class': 'ckeditor'
+            'class': 'ckeditor_instance'
         },
     }
     inline_models = [InlineFile(DailyScheduleFile)]
@@ -1051,7 +1051,7 @@ class TabledCommitteeReportView(ViewWithFiles, MyModelView):
     column_searchable_list = ('title', )
     form_widget_args = {
         'body': {
-            'class': 'ckeditor'
+            'class': 'ckeditor_instance'
         },
     }
     form_columns = (
@@ -1080,7 +1080,7 @@ class EmailTemplateView(MyModelView):
     )
     form_widget_args = {
         'body': {
-            'class': 'ckeditor'
+            'class': 'ckeditor_instance'
         },
     }
 
@@ -1354,7 +1354,7 @@ class PageView(ViewWithFiles, MyModelView):
     }
     form_widget_args = {
         'body': {
-            'class': 'ckeditor'
+            'class': 'ckeditor_instance'
         },
         'path': {
             'readonly': True
@@ -1391,7 +1391,7 @@ class PostView(ViewWithFiles, MyModelView):
     }
     form_widget_args = {
         'body': {
-            'class': 'ckeditor'
+            'class': 'ckeditor_instance'
         },
         'path': {
             'readonly': True

--- a/pmg/admin/__init__.py
+++ b/pmg/admin/__init__.py
@@ -445,10 +445,10 @@ class CommitteeView(MyModelView):
     )
     form_widget_args = {
         'about': {
-            'class': 'ckeditor_instance'
+            'class': 'pmg_ckeditor'
         },
         'contact_details': {
-            'class': 'ckeditor_instance'
+            'class': 'pmg_ckeditor'
         },
     }
     form_args = {
@@ -657,10 +657,10 @@ class CommitteeMeetingView(EventView):
     }
     form_widget_args = {
         'body': {
-            'class': 'ckeditor_instance'
+            'class': 'pmg_ckeditor'
         },
         'summary': {
-            'class': 'ckeditor_instance'
+            'class': 'pmg_ckeditor'
         }
     }
     form_ajax_refs = {'bills': {'fields': ('title', ), 'page_size': 50}}
@@ -711,7 +711,7 @@ class HansardView(EventView):
     }
     form_widget_args = {
         'body': {
-            'class': 'ckeditor_instance'
+            'class': 'pmg_ckeditor'
         },
     }
     form_ajax_refs = {'bills': {'fields': ('title', ), 'page_size': 50}}
@@ -731,7 +731,7 @@ class ProvincialLegislatureView(MyModelView):
     )
     form_widget_args = {
         'contact_details': {
-            'class': 'ckeditor_instance'
+            'class': 'pmg_ckeditor'
         },
         'name': {
             'readonly': True
@@ -780,10 +780,10 @@ class BriefingView(EventView):
     )
     form_widget_args = {
         'summary': {
-            'class': 'ckeditor_instance'
+            'class': 'pmg_ckeditor'
         },
         'body': {
-            'class': 'ckeditor_instance'
+            'class': 'pmg_ckeditor'
         },
     }
     inline_models = [InlineFile(EventFile)]
@@ -898,7 +898,7 @@ class CommitteeQuestionView(MyModelView):
     }
     form_widget_args = {
         'answer': {
-            'class': 'ckeditor_instance'
+            'class': 'pmg_ckeditor'
         },
     }
     form_ajax_refs = {
@@ -961,7 +961,7 @@ class QuestionReplyView(MyModelView):
     )
     form_widget_args = {
         'body': {
-            'class': 'ckeditor_instance'
+            'class': 'pmg_ckeditor'
         },
     }
     inline_models = [InlineFile(QuestionReplyFile)]
@@ -993,7 +993,7 @@ class CallForCommentView(MyModelView):
     )
     form_widget_args = {
         'body': {
-            'class': 'ckeditor_instance'
+            'class': 'pmg_ckeditor'
         },
     }
 
@@ -1015,7 +1015,7 @@ class DailyScheduleView(ViewWithFiles, MyModelView):
     )
     form_widget_args = {
         'body': {
-            'class': 'ckeditor_instance'
+            'class': 'pmg_ckeditor'
         },
     }
     inline_models = [InlineFile(DailyScheduleFile)]
@@ -1051,7 +1051,7 @@ class TabledCommitteeReportView(ViewWithFiles, MyModelView):
     column_searchable_list = ('title', )
     form_widget_args = {
         'body': {
-            'class': 'ckeditor_instance'
+            'class': 'pmg_ckeditor'
         },
     }
     form_columns = (
@@ -1080,7 +1080,7 @@ class EmailTemplateView(MyModelView):
     )
     form_widget_args = {
         'body': {
-            'class': 'ckeditor_instance'
+            'class': 'pmg_ckeditor'
         },
     }
 
@@ -1354,7 +1354,7 @@ class PageView(ViewWithFiles, MyModelView):
     }
     form_widget_args = {
         'body': {
-            'class': 'ckeditor_instance'
+            'class': 'pmg_ckeditor'
         },
         'path': {
             'readonly': True
@@ -1391,7 +1391,7 @@ class PostView(ViewWithFiles, MyModelView):
     }
     form_widget_args = {
         'body': {
-            'class': 'ckeditor_instance'
+            'class': 'pmg_ckeditor'
         },
         'path': {
             'readonly': True

--- a/pmg/static/resources/javascript/admin/admin.js
+++ b/pmg/static/resources/javascript/admin/admin.js
@@ -1,5 +1,5 @@
 $(function() {
-  $('.ckeditor_instance').each(function() {
+  $('.pmg_ckeditor').each(function() {
     CKEDITOR.replace(this, {
       extraPlugins: 'autogrow',
       height: 200,

--- a/pmg/static/resources/javascript/admin/admin.js
+++ b/pmg/static/resources/javascript/admin/admin.js
@@ -1,7 +1,5 @@
 $(function() {
-  $('.ckeditor').each(function() {
-    var editor = CKEDITOR.instances[this.id];
-    editor.destroy(true);
+  $('.ckeditor_instance').each(function() {
     CKEDITOR.replace(this, {
       extraPlugins: 'autogrow',
       height: 200,

--- a/pmg/static/resources/javascript/admin/admin.js
+++ b/pmg/static/resources/javascript/admin/admin.js
@@ -1,5 +1,7 @@
 $(function() {
   $('.ckeditor').each(function() {
+    var editor = CKEDITOR.instances[this.id];
+    editor.destroy(true);
     CKEDITOR.replace(this, {
       extraPlugins: 'autogrow',
       height: 200,

--- a/pmg/templates/admin/my_base.html
+++ b/pmg/templates/admin/my_base.html
@@ -21,7 +21,7 @@
 
 {% block tail_js -%}
   {{ super() }}
-  <script src="//cdn.ckeditor.com/4.6.0/standard-all/ckeditor.js"></script>
+  <script src="//cdn.ckeditor.com/4.13.0/standard-all/ckeditor.js"></script>
   {% assets "admin-js" %}
     <script type="text/javascript" src="{{ ASSET_URL }}"></script>
   {% endassets %}

--- a/pmg/templates/admin/my_base.html
+++ b/pmg/templates/admin/my_base.html
@@ -21,7 +21,7 @@
 
 {% block tail_js -%}
   {{ super() }}
-  <script src="//cdn.ckeditor.com/4.13.0/standard-all/ckeditor.js"></script>
+  <script src="//cdn.ckeditor.com/4.4.7/standard-all/ckeditor.js"></script>
   {% assets "admin-js" %}
     <script type="text/javascript" src="{{ ASSET_URL }}"></script>
   {% endassets %}

--- a/pmg/templates/admin/my_base.html
+++ b/pmg/templates/admin/my_base.html
@@ -21,7 +21,7 @@
 
 {% block tail_js -%}
   {{ super() }}
-  <script src="//cdn.ckeditor.com/4.4.7/standard-all/ckeditor.js"></script>
+  <script src="//cdn.ckeditor.com/4.6.0/standard-all/ckeditor.js"></script>
   {% assets "admin-js" %}
     <script type="text/javascript" src="{{ ASSET_URL }}"></script>
   {% endassets %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,4 +86,4 @@ XlsxWriter==0.6.6
 xlrd==1.0.0
 # Heroku (thus dokku) recomments editable if from git and relying on on upstream changes
 # https://devcenter.heroku.com/articles/python-pip#git-backed-distributions
--e git+https://github.com/Code4SA/za-parliament-scrapers.git@master#egg=za_parliament_scrapers
+-e git+https://github.com/Code4SA/za-parliament-scrapers.git@c9a4a1f4f02152bd2a7c25977a843e2d5e2fe656#egg=za_parliament_scrapers


### PR DESCRIPTION
This PR fixes the errors reported about the HTML editor elements in the admin site.

Somehow CKEditor instances were created before our [admin.js](https://github.com/OpenUpSA/pmg-cms-2/blob/master/pmg/static/resources/javascript/admin/admin.js#L3) script was supposed to create them. There must be a selector somewhere that creates a CKEditor instance for all elements with the `ckeditor` class, but I can't find it anywhere (checked in FlaskAdmin as well).

So I changed the class name of all of the admin fields we want to be CKEditors to `ckeditor_instance` so that it won't be created before we want it to be created with our settings.

Our settings include the `autogrow` plugin which when we don't have it installed, causes the second error reported and `disallowedContent: 'a[!name]'` which absence causes anchors to be created from bookmarks pasted from Word documents. 

[Pivotal](https://www.pivotaltracker.com/n/projects/1367366/stories/171251893)