### PR TITLE
Cascade file deletions to event_files

### DIFF
--- a/pmg/models/resources.py
+++ b/pmg/models/resources.py
@@ -231,7 +231,7 @@ class File(db.Model):
     origname = db.Column(db.String(255))
     description = db.Column(db.String(255))
     playtime = db.Column(db.String(10))
-    event_files = db.relationship("EventFile", lazy=True)
+    event_files = db.relationship("EventFile", lazy=True, cascade="all, delete")
 
     def to_dict(self, include_related=False):
         tmp = serializers.model_to_dict(self, include_related=include_related)

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -9,30 +9,31 @@ from tests.fixtures import dbfixture, CommitteeData, CommitteeMeetingData, Event
 class TestFiles(PMGTestCase):
     def setUp(self):
         super().setUp()
-        self.fx = dbfixture.data(CommitteeMeetingData)
-        self.fx.setup()
-
         self.house = House(name="National Assembly", name_short="NA", sphere="national")
-
-        committee_meeting_id = self.fx.CommitteeMeetingData.arts_meeting_one.id
-        self.committee_meeting = CommitteeMeeting.query.filter_by(
-            id=committee_meeting_id
-        ).first()
+        self.committee = Committee(
+            name="Communications", house=self.house, premium=True
+        )
+        self.committee_meeting = CommitteeMeeting(
+            date=datetime.datetime(2019, 1, 1, 0, 0, 0, tzinfo=pytz.utc),
+            title="Public meeting One",
+            committee=self.committee,
+        )
         self.file = File(file_path="test-path.pdf")
         self.event_file = EventFile(event=self.committee_meeting, file=self.file)
+        db.session.add(self.house)
+        db.session.add(self.committee)
+        db.session.add(self.committee_meeting)
         db.session.add(self.event_file)
         db.session.commit()
+        self.file_id = self.file.id
 
     def test_delete_file_when_linked_to_meeting(self):
-        # WHEN we delete the file
+        # When we delete the file, the event should be deleted too, but
+        # the meeting shouldn't be deleted
         db.session.delete(self.file)
         db.session.commit()
-
-        # THEN the event should be deleted too
-        event_file = EventFile.query.filter_by(file_id=self.file.id).first()
+        event_file = EventFile.query.filter_by(file_id=self.file_id).first()
         self.assertIsNone(event_file)
-
-        # THEN the meeting should still exist
         committee_meeting = CommitteeMeeting.query.filter_by(
             id=self.committee_meeting.id
         ).first()

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -49,8 +49,8 @@ class TestFiles(PMGTestCase):
 
     @patch("pmg.models.resources.s3_bucket", return_value=MockS3())
     def test_delete_file_when_linked_to_meeting(self, mock_s3_bucket_key):
-        # When we delete the file, the event should be deleted too, but
-        # the meeting shouldn't be deleted
+        # When we delete the file, the event_file many-to-many join table entries for the file 
+        # should also be deleted but the meeting (event) should not be deleted
         db.session.delete(self.file)
         db.session.commit()
         event_file = EventFile.query.filter_by(file_id=self.file_id).first()

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -5,17 +5,16 @@ from pmg.models import db, CommitteeMeeting, Event, EventFile, File, House, Comm
 from tests.fixtures import dbfixture, CommitteeData, CommitteeMeetingData, EventData
 
 
-# TODO: might have to mock S3
 class TestFiles(PMGTestCase):
     def setUp(self):
         super().setUp()
-        self.house = House(name="National Assembly", name_short="NA", sphere="national")
+        self.house = House(name="Test House", name_short="TH", sphere="national")
         self.committee = Committee(
-            name="Communications", house=self.house, premium=True
+            name="Test Committee", house=self.house, premium=True
         )
         self.committee_meeting = CommitteeMeeting(
             date=datetime.datetime(2019, 1, 1, 0, 0, 0, tzinfo=pytz.utc),
-            title="Public meeting One",
+            title="Test meeting",
             committee=self.committee,
         )
         self.file = File(file_path="test-path.pdf")

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -1,0 +1,40 @@
+from tests import PMGTestCase
+import datetime
+import pytz
+from pmg.models import db, CommitteeMeeting, Event, EventFile, File, House, Committee
+from tests.fixtures import dbfixture, CommitteeData, CommitteeMeetingData, EventData
+
+
+# TODO: might have to mock S3
+class TestFiles(PMGTestCase):
+    def setUp(self):
+        super().setUp()
+        self.house = House(name="National Assembly", name_short="NA", sphere="national")
+        self.committee = Committee(
+            name="Communications", house=self.house, premium=True
+        )
+        self.committee_meeting = CommitteeMeeting(
+            date=datetime.datetime(2019, 1, 1, 0, 0, 0, tzinfo=pytz.utc),
+            title="Public meeting One",
+            committee=self.committee,
+        )
+        self.file = File(file_path="test-path.pdf")
+        self.event_file = EventFile(event=self.committee_meeting, file=self.file)
+        db.session.add(self.house)
+        db.session.add(self.committee)
+        db.session.add(self.committee_meeting)
+        db.session.add(self.event_file)
+        db.session.commit()
+        self.file_id = self.file.id
+
+    def test_delete_file_when_linked_to_meeting(self):
+        # When we delete the file, the event should be deleted too, but
+        # the meeting shouldn't be deleted
+        db.session.delete(self.file)
+        db.session.commit()
+        event_file = EventFile.query.filter_by(file_id=self.file_id).first()
+        self.assertIsNone(event_file)
+        committee_meeting = CommitteeMeeting.query.filter_by(
+            id=self.committee_meeting.id
+        ).first()
+        self.assertIsNotNone(committee_meeting)

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -49,7 +49,7 @@ class TestFiles(PMGTestCase):
 
     @patch("pmg.models.resources.s3_bucket", return_value=MockS3())
     def test_delete_file_when_linked_to_meeting(self, mock_s3_bucket_key):
-        # When we delete the file, the event_file many-to-many join table entries for the file 
+        # When we delete the file, the event_file many-to-many join table entries for the file
         # should also be deleted but the meeting (event) should not be deleted
         db.session.delete(self.file)
         db.session.commit()

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -9,31 +9,30 @@ from tests.fixtures import dbfixture, CommitteeData, CommitteeMeetingData, Event
 class TestFiles(PMGTestCase):
     def setUp(self):
         super().setUp()
+        self.fx = dbfixture.data(CommitteeMeetingData)
+        self.fx.setup()
+
         self.house = House(name="National Assembly", name_short="NA", sphere="national")
-        self.committee = Committee(
-            name="Communications", house=self.house, premium=True
-        )
-        self.committee_meeting = CommitteeMeeting(
-            date=datetime.datetime(2019, 1, 1, 0, 0, 0, tzinfo=pytz.utc),
-            title="Public meeting One",
-            committee=self.committee,
-        )
+
+        committee_meeting_id = self.fx.CommitteeMeetingData.arts_meeting_one.id
+        self.committee_meeting = CommitteeMeeting.query.filter_by(
+            id=committee_meeting_id
+        ).first()
         self.file = File(file_path="test-path.pdf")
         self.event_file = EventFile(event=self.committee_meeting, file=self.file)
-        db.session.add(self.house)
-        db.session.add(self.committee)
-        db.session.add(self.committee_meeting)
         db.session.add(self.event_file)
         db.session.commit()
-        self.file_id = self.file.id
 
     def test_delete_file_when_linked_to_meeting(self):
-        # When we delete the file, the event should be deleted too, but
-        # the meeting shouldn't be deleted
+        # WHEN we delete the file
         db.session.delete(self.file)
         db.session.commit()
-        event_file = EventFile.query.filter_by(file_id=self.file_id).first()
+
+        # THEN the event should be deleted too
+        event_file = EventFile.query.filter_by(file_id=self.file.id).first()
         self.assertIsNone(event_file)
+
+        # THEN the meeting should still exist
         committee_meeting = CommitteeMeeting.query.filter_by(
             id=self.committee_meeting.id
         ).first()


### PR DESCRIPTION
When someone deletes a file, the file needs to be automatically unlinked from a event (such as a committee meeting) as well.

[Pivotal](https://www.pivotaltracker.com/story/show/172451735)