### PR TITLE
Fix timezone display

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -3,4 +3,4 @@ version: '3'
 services:
   web:
     environment:
-      - SQLALCHEMY_DATABASE_URI=postgresql://pmg:pmg@postgres/pmg_test?client_encoding=utf8
+      - SQLALCHEMY_DATABASE_URI=postgresql://pmg:pmg@postgres/pmg_test?client_encoding=utf8&options=-c%20timezone%3DAfrica%2FJohannesburg

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -3,4 +3,4 @@ version: '3'
 services:
   web:
     environment:
-      - SQLALCHEMY_DATABASE_URI=postgresql://pmg:pmg@postgres/pmg_test?client_encoding=utf8&options=-c timezone=Africa/Johannesburg
+      - SQLALCHEMY_DATABASE_URI=postgresql://pmg:pmg@postgres/pmg_test?client_encoding=utf8&options=-c%20timezone%3DAfrica%2FJohannesburg

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -3,4 +3,4 @@ version: '3'
 services:
   web:
     environment:
-      - SQLALCHEMY_DATABASE_URI=postgresql://pmg:pmg@postgres/pmg_test?client_encoding=utf8&options=-c%20timezone%3DAfrica%2FJohannesburg
+      - SQLALCHEMY_DATABASE_URI=postgresql://pmg:pmg@postgres/pmg_test?client_encoding=utf8&options=-c timezone=Africa/Johannesburg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - .:/app
     environment:
-      - SQLALCHEMY_DATABASE_URI=postgresql://pmg:pmg@postgres/pmg?client_encoding=utf8
+      - SQLALCHEMY_DATABASE_URI=postgresql://pmg:pmg@postgres/pmg?client_encoding=utf8&options=-c%20timezone%3DAfrica%2FJohannesburg
       - ES_SERVER=http://elastic:9200
     ports:
       - "5000:5000"

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -17,8 +17,11 @@ logger = logging.getLogger('alembic.env')
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
 from flask import current_app
-config.set_main_option('sqlalchemy.url',
-                       current_app.config.get('SQLALCHEMY_DATABASE_URI').replace("%", "%%"))
+
+# Replace %s with %%s so that Alembic doesn't think the URL-encoded values
+# are interpolation values
+database_uri = current_app.config.get('SQLALCHEMY_DATABASE_URI').replace("%", "%%")
+config.set_main_option('sqlalchemy.url', database_uri)
 target_metadata = current_app.extensions['migrate'].db.metadata
 
 # other values from the config, defined by the needs of env.py,

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -18,7 +18,7 @@ logger = logging.getLogger('alembic.env')
 # target_metadata = mymodel.Base.metadata
 from flask import current_app
 config.set_main_option('sqlalchemy.url',
-                       current_app.config.get('SQLALCHEMY_DATABASE_URI'))
+                       current_app.config.get('SQLALCHEMY_DATABASE_URI').replace("%", "%%"))
 target_metadata = current_app.extensions['migrate'].db.metadata
 
 # other values from the config, defined by the needs of env.py,

--- a/pmg/api/schemas.py
+++ b/pmg/api/schemas.py
@@ -1,5 +1,6 @@
 from marshmallow import fields
 from marshmallow_polyfield import PolyField
+from marshmallow.fields import LocalDateTime
 
 from pmg import ma
 from pmg.models import (
@@ -140,6 +141,7 @@ class CommitteeMeetingSchema(ma.ModelSchema):
     summary = fields.Method("get_summary")
     files = fields.Nested("FileSchema", attribute="api_files", many=True)
     bills = fields.Nested("BillSchema", many=True, exclude=["events", "versions"])
+    date = fields.LocalDateTime(attribute="date")
     _links = ma.Hyperlinks(
         {
             "self": AbsoluteUrlFor("api2.committee_meetings", id="<id>"),

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -135,7 +135,9 @@ class CommitteeMeetingData(DataSet):
         committee = CommitteeData.arts
 
     class premium_recent:
-        date = datetime.datetime(THIS_YEAR, 11, 5, 0, 0, 0, tzinfo=pytz.utc)
+        date = datetime.datetime(
+            THIS_YEAR, 11, 5, 0, 0, 0, tzinfo=pytz.FixedOffset(120)
+        )
         title = "Premium meeting recent"
         committee = CommitteeData.communications
 

--- a/tests/views/test_admin_committee_meetings.py
+++ b/tests/views/test_admin_committee_meetings.py
@@ -20,6 +20,36 @@ class TestAdminCommitteeMeetings(PMGLiveServerTestCase):
         self.fx.teardown()
         super().tearDown()
 
+    def test_update_committee_meeting(self):
+        url = "/admin/committee-meeting/edit/?id=%d"
+        meeting = self.fx.CommitteeMeetingData.premium_recent
+        meeting_data = {
+            "title": "Meeting title",
+            "date": "2020-02-20 22:00:00",
+        }
+        response = self.make_request(
+            url % meeting.id,
+            self.user,
+            data=meeting_data,
+            method="POST",
+            follow_redirects=True,
+        )
+
+        self.assertIn(meeting_data["title"], self.html)
+        self.assertIn(meeting_data["date"], self.html)
+
+        # Save the meeting again without changing the date 
+        # to check that the date doesn't change
+        response = self.make_request(
+            url % meeting.id,
+            self.user,
+            data={},
+            method="POST",
+            follow_redirects=True,
+        )
+        self.assertIn(meeting_data["title"], self.html)
+        self.assertIn(meeting_data["date"], self.html)
+
     def test_view_admin_committee_meeting_page(self):
         """
         Test view admin committee page (/admin/committee-meeting)

--- a/tests/views/test_admin_committee_meetings.py
+++ b/tests/views/test_admin_committee_meetings.py
@@ -38,14 +38,10 @@ class TestAdminCommitteeMeetings(PMGLiveServerTestCase):
         self.assertIn(meeting_data["title"], self.html)
         self.assertIn(meeting_data["date"], self.html)
 
-        # Save the meeting again without changing the date 
+        # Save the meeting again without changing the date
         # to check that the date doesn't change
         response = self.make_request(
-            url % meeting.id,
-            self.user,
-            data={},
-            method="POST",
-            follow_redirects=True,
+            url % meeting.id, self.user, data={}, method="POST", follow_redirects=True,
         )
         self.assertIn(meeting_data["title"], self.html)
         self.assertIn(meeting_data["date"], self.html)

--- a/tests/views/test_admin_committee_meetings.py
+++ b/tests/views/test_admin_committee_meetings.py
@@ -1,0 +1,33 @@
+from builtins import str
+import datetime
+from tests import PMGLiveServerTestCase
+from pmg.models import db, Committee
+from tests.fixtures import dbfixture, UserData, CommitteeMeetingData
+
+THIS_YEAR = datetime.datetime.today().year
+
+
+class TestAdminCommitteeMeetings(PMGLiveServerTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.fx = dbfixture.data(UserData, CommitteeMeetingData)
+        self.fx.setup()
+        self.user = self.fx.UserData.admin
+
+    def tearDown(self):
+        self.delete_created_objects()
+        self.fx.teardown()
+        super().tearDown()
+
+    def test_view_admin_committee_meeting_page(self):
+        """
+        Test view admin committee page (/admin/committee-meeting)
+        """
+        self.make_request("/admin/committee-meeting", self.user, follow_redirects=True)
+        self.assertIn("Committee Meetings", self.html)
+        self.assertIn(self.fx.CommitteeMeetingData.arts_meeting_one.title, self.html)
+        self.assertIn("2019-01-01 02:00:00", self.html)
+
+        self.assertIn(self.fx.CommitteeMeetingData.premium_recent.title, self.html)
+        self.assertIn("%d-11-05 00:00:00" % THIS_YEAR, self.html)

--- a/tests/views/test_committee_meeting_page.py
+++ b/tests/views/test_committee_meeting_page.py
@@ -1,3 +1,4 @@
+import datetime
 from tests import PMGLiveServerTestCase
 from tests.fixtures import dbfixture, HouseData, CommitteeData, CommitteeMeetingData
 import urllib.request, urllib.error, urllib.parse
@@ -21,4 +22,5 @@ class TestCommitteeMeetingPage(PMGLiveServerTestCase):
         meeting = self.fx.CommitteeMeetingData.premium_recent
         self.make_request("/committee-meeting/%s/" % meeting.id)
         self.assertIn(meeting.title, self.html)
+        self.assertIn("5 November %d" % datetime.datetime.today().year, self.html)
         self.assertIn("Follow this committee", self.html)


### PR DESCRIPTION
Set the timezone option for Postgres to 'Africa/Johannesburg' so that all timezone-aware times are returned in that zone from Postgres.

From the Postgres [docs](https://www.postgresql.org/docs/8.3/datatype-datetime.html#DATATYPE-TIMEZONES):

> All timezone-aware dates and times are stored internally in UTC. They are converted to local time in the zone specified by the timezone configuration parameter before being displayed to the client.

We also need to use the `LocalDateTime` field in the Marshmallow schemas because the default [`DateTime`](https://marshmallow.readthedocs.io/en/2.x-line/api_reference.html#marshmallow.fields.DateTime) field in Marshmallow < 3.0.0 converts all dates to UTC.

TODO:
- [ ] Use the `LocalDateTime` field in other schemas that contain dates as well.
- [ ] Considering upgrading to Marshmallow > 3.0.0 instead because in newer versions dates [aren't](https://marshmallow.readthedocs.io/en/stable/upgrading.html#datetime-leaves-timezone-information-untouched-during-serialization) automatically converted to UTC.