### PR TITLE
Fix timezone display (no changes to database connection)

### DIFF
--- a/pmg/admin/__init__.py
+++ b/pmg/admin/__init__.py
@@ -544,6 +544,7 @@ class EventView(ViewWithFiles, MyModelView):
 
     form_excluded_columns = ("type",)
     column_exclude_list = ("type",)
+    column_formatters = {"date": lambda v, c, model, n: model.date.astimezone(SAST)}
 
     def on_form_prefill(self, form, id):
         super().on_form_prefill(form, id)

--- a/pmg/admin/__init__.py
+++ b/pmg/admin/__init__.py
@@ -545,6 +545,11 @@ class EventView(ViewWithFiles, MyModelView):
     form_excluded_columns = ("type",)
     column_exclude_list = ("type",)
 
+    def on_form_prefill(self, form, id):
+        super().on_form_prefill(form, id)
+        # Display date in South African time
+        form.date.data = form.date.object_data.astimezone(SAST)
+
     def __init__(self, model, session, **kwargs):
         self.type = kwargs.pop("type")
         super(EventView, self).__init__(model, session, **kwargs)

--- a/pmg/api/schemas.py
+++ b/pmg/api/schemas.py
@@ -1,6 +1,5 @@
 from marshmallow import fields
 from marshmallow_polyfield import PolyField
-from marshmallow.fields import LocalDateTime
 
 from pmg import ma
 from pmg.models import (
@@ -141,7 +140,6 @@ class CommitteeMeetingSchema(ma.ModelSchema):
     summary = fields.Method("get_summary")
     files = fields.Nested("FileSchema", attribute="api_files", many=True)
     bills = fields.Nested("BillSchema", many=True, exclude=["events", "versions"])
-    date = fields.LocalDateTime(attribute="date")
     _links = ma.Hyperlinks(
         {
             "self": AbsoluteUrlFor("api2.committee_meetings", id="<id>"),

--- a/pmg/api/schemas.py
+++ b/pmg/api/schemas.py
@@ -1,5 +1,6 @@
 from marshmallow import fields
 from marshmallow_polyfield import PolyField
+from marshmallow.fields import LocalDateTime
 
 from pmg import ma
 from pmg.models import (
@@ -140,6 +141,7 @@ class CommitteeMeetingSchema(ma.ModelSchema):
     summary = fields.Method("get_summary")
     files = fields.Nested("FileSchema", attribute="api_files", many=True)
     bills = fields.Nested("BillSchema", many=True, exclude=["events", "versions"])
+    date = fields.LocalDateTime(attribute="date")
     _links = ma.Hyperlinks(
         {
             "self": AbsoluteUrlFor("api2.committee_meetings", id="<id>"),

--- a/pmg/helpers.py
+++ b/pmg/helpers.py
@@ -10,9 +10,12 @@ from flask import request, url_for
 from pmg import app
 from pmg.ga import get_ga_events
 from pmg.forms import CorrectThisPageForm
+import pytz
 
 
 logger = logging.getLogger(__name__)
+
+SAST = pytz.FixedOffset(120)
 
 
 @app.context_processor
@@ -79,7 +82,7 @@ def _jinja2_filter_datetime(iso_str, format_option=None):
         # as an reporting axis
         format = "%Y-%m"
 
-    return d.strftime(format)
+    return d.astimezone(SAST).strftime(format)
 
 
 @app.template_filter("member_url")

--- a/pmg/helpers.py
+++ b/pmg/helpers.py
@@ -15,7 +15,7 @@ import pytz
 
 logger = logging.getLogger(__name__)
 
-SAST = pytz.FixedOffset(120)
+SAST = pytz.timezone("Africa/Johannesburg")
 
 
 @app.context_processor

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -135,7 +135,9 @@ class CommitteeMeetingData(DataSet):
         committee = CommitteeData.arts
 
     class premium_recent:
-        date = datetime.datetime(THIS_YEAR, 11, 5, 0, 0, 0, tzinfo=pytz.utc)
+        date = datetime.datetime(
+            THIS_YEAR, 11, 5, 0, 0, 0, tzinfo=pytz.FixedOffset(120)
+        )
         title = "Premium meeting recent"
         committee = CommitteeData.communications
 

--- a/tests/views/test_admin_committee_meetings.py
+++ b/tests/views/test_admin_committee_meetings.py
@@ -1,0 +1,59 @@
+from builtins import str
+import datetime
+from tests import PMGLiveServerTestCase
+from pmg.models import db, Committee
+from tests.fixtures import dbfixture, UserData, CommitteeMeetingData
+
+THIS_YEAR = datetime.datetime.today().year
+
+
+class TestAdminCommitteeMeetings(PMGLiveServerTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.fx = dbfixture.data(UserData, CommitteeMeetingData)
+        self.fx.setup()
+        self.user = self.fx.UserData.admin
+
+    def tearDown(self):
+        self.delete_created_objects()
+        self.fx.teardown()
+        super().tearDown()
+
+    def test_update_committee_meeting(self):
+        url = "/admin/committee-meeting/edit/?id=%d"
+        meeting = self.fx.CommitteeMeetingData.premium_recent
+        meeting_data = {
+            "title": "Meeting title",
+            "date": "2020-02-20 22:00:00",
+        }
+        response = self.make_request(
+            url % meeting.id,
+            self.user,
+            data=meeting_data,
+            method="POST",
+            follow_redirects=True,
+        )
+
+        self.assertIn(meeting_data["title"], self.html)
+        self.assertIn(meeting_data["date"], self.html)
+
+        # Save the meeting again without changing the date
+        # to check that the date doesn't change
+        response = self.make_request(
+            url % meeting.id, self.user, data={}, method="POST", follow_redirects=True,
+        )
+        self.assertIn(meeting_data["title"], self.html)
+        self.assertIn(meeting_data["date"], self.html)
+
+    def test_view_admin_committee_meeting_page(self):
+        """
+        Test view admin committee page (/admin/committee-meeting)
+        """
+        self.make_request("/admin/committee-meeting", self.user, follow_redirects=True)
+        self.assertIn("Committee Meetings", self.html)
+        self.assertIn(self.fx.CommitteeMeetingData.arts_meeting_one.title, self.html)
+        self.assertIn("2019-01-01 02:00:00", self.html)
+
+        self.assertIn(self.fx.CommitteeMeetingData.premium_recent.title, self.html)
+        self.assertIn("%d-11-05 00:00:00" % THIS_YEAR, self.html)

--- a/tests/views/test_committee_meeting_page.py
+++ b/tests/views/test_committee_meeting_page.py
@@ -1,3 +1,4 @@
+import datetime
 from tests import PMGLiveServerTestCase
 from tests.fixtures import dbfixture, HouseData, CommitteeData, CommitteeMeetingData
 import urllib.request, urllib.error, urllib.parse
@@ -21,4 +22,5 @@ class TestCommitteeMeetingPage(PMGLiveServerTestCase):
         meeting = self.fx.CommitteeMeetingData.premium_recent
         self.make_request("/committee-meeting/%s/" % meeting.id)
         self.assertIn(meeting.title, self.html)
+        self.assertIn("5 November %d" % datetime.datetime.today().year, self.html)
         self.assertIn("Follow this committee", self.html)


### PR DESCRIPTION
Fixes the same issue as #409, but doesn't alter the database connection options.

Instead, changes the display logic of Flask Admin and Jinja so ensure that dates always get displayed in South African time.

~~TODO:~~
~~- [ ] Check how the change to `pretty_date` affects other models or move it to a separate filter.~~
~~- [ ] Use the same `on_form_prefill` and `column_formatters` for other models with dates.~~
Will make updates for other models in a next PR.