### PR TITLE
Add try-catch for Soundcloud sync state

### DIFF
--- a/pmg/models/soundcloud_track.py
+++ b/pmg/models/soundcloud_track.py
@@ -204,7 +204,7 @@ class SoundcloudTrack(db.Model):
             try:
                 track.sync_state(client)
             except Exception as e:
-                logger.error("Soundcloud sync_state failed with: %s" % e)
+                logger.error("Soundcloud sync_state failed for %s with: %s" % (track.uri, e))
 
     @classmethod
     def handle_failed(cls, client):

--- a/pmg/models/soundcloud_track.py
+++ b/pmg/models/soundcloud_track.py
@@ -201,7 +201,10 @@ class SoundcloudTrack(db.Model):
             .all()
         )
         for track in tracks:
-            track.sync_state(client)
+            try:
+                track.sync_state(client)
+            except Exception as e:
+                logger.error("Soundcloud sync_state failed with: %s" % e)
 
     @classmethod
     def handle_failed(cls, client):


### PR DESCRIPTION
We're getting a [404](https://sentry.io/organizations/openupsa/issues/1981551299/?project=1489874&query=is%3Aunresolved) for some of the old tracks. Log error for those tracks, but continue processing the next ones.