### PR TITLE
Remove twitter timeline from home

### DIFF
--- a/pmg/templates/index.html
+++ b/pmg/templates/index.html
@@ -212,10 +212,7 @@
 
         </div>
         <div class="col-md-3">
-            <div class="hidden-xs">
-		<a class="twitter-timeline" data-height="800" href="https://twitter.com/PMG_SA/lists/members-of-parliament?ref_src=twsrc%5Etfw">A Twitter List by PMG_SA</a>
-		<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-          </div>
+            
         </div>
       </div>
     </div>


### PR DESCRIPTION
Embedded twitter timelines don't work anymore. It seems to be a common problem with no real  agreement on the cause.