### PR TITLE
CKEditor update

### DIFF
--- a/pmg/static/resources/javascript/admin/admin.js
+++ b/pmg/static/resources/javascript/admin/admin.js
@@ -6,7 +6,8 @@ $(function() {
       autoGrow_minHeight: 200,
       autoGrow_maxHeight: 600,
       disallowedContent: 'a[!name]',
-      allowedContent: true
+      allowedContent: true,
+      versionCheck: false
     });
   });
 });

--- a/pmg/templates/admin/my_base.html
+++ b/pmg/templates/admin/my_base.html
@@ -21,7 +21,7 @@
 
 {% block tail_js -%}
   {{ super() }}
-  <script src="//cdn.ckeditor.com/4.4.7/standard-all/ckeditor.js"></script>
+  <script src="//cdn.ckeditor.com/4.22.1/standard-all/ckeditor.js"></script>
   {% assets "admin-js" %}
     <script type="text/javascript" src="{{ ASSET_URL }}"></script>
   {% endassets %}


### PR DESCRIPTION
Update to 4.22.1. The last free version. Turned off security warning.