### PR TITLE
debugging. disabling reports on petitions admin view

### DIFF
--- a/pmg/admin/__init__.py
+++ b/pmg/admin/__init__.py
@@ -1454,7 +1454,6 @@ class PetitionView(MyModelView):
     form_columns = (
         "house",
         "committee", 
-        "report",
         "hansard",
         "title",
         "date",


### PR DESCRIPTION
The admin view is crashing. It's an issue with select2, but I think it's something with the Files. So just disabling it for now to test.